### PR TITLE
COC-14 Optimize DB calls for Recipe Index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Stupid MacOS
+*.DS_Store

--- a/Take02/Controllers/Helper.cs
+++ b/Take02/Controllers/Helper.cs
@@ -288,24 +288,6 @@ namespace Take02.Controllers
             return model;
         }
 
-        public static async Task<List<RecipeViewModel>> GetRecipeViewModelsAsync(CocktailsContext _context, bool includeIngredients = false)
-        {
-            var recipes = await GetRecipesAsync(_context);
-
-            var models = recipes.Select(t => GetRecipeViewModelAsync(_context, t.Id).Result).ToList();
-
-            if (includeIngredients)
-            {
-                foreach (var model in models)
-                {
-                    model.IngredientViewModels = await GetIngredientViewModelsByRecipeAsync(_context, model.Id);
-                    model.ShowIngredients = includeIngredients;
-                }
-            }
-
-            return models;
-        }
-
         #endregion ViewModel Methods
 
         #region SelectListItems Methods

--- a/Take02/Controllers/RecipesController.cs
+++ b/Take02/Controllers/RecipesController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -29,8 +28,6 @@ namespace Take02.Controllers
         // GET: Recipes
         public async Task<IActionResult> Index(bool showIngredients = false)
         {
-            var stopwatch = Stopwatch.StartNew();
-
             var allRecipesTask = _recipeService.GetAllRecipesAsync();
             var allLibrariesTask = _libraryService.GetAllLibrariesAsync();
             var allMixTypesTask = _recipeService.GetAllMixTypesAsync();

--- a/Take02/Services/LibraryService.cs
+++ b/Take02/Services/LibraryService.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Take02.Models;
+using Take02.ViewModels;
+
+namespace Take02.Services
+{
+    public interface ILibraryService
+    {
+        Task<ICollection<Library>> GetAllLibrariesAsync();
+        Task<Library> GetLibraryAsync(Guid id);
+    }
+
+    public class LibraryService : ILibraryService
+    {
+        private readonly CocktailsContext _db;
+
+        public LibraryService(CocktailsContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<ICollection<Library>> GetAllLibrariesAsync()
+        {
+            return (await _db.Library.ToListAsync());
+        }
+
+        public async Task<Library> GetLibraryAsync(Guid id)
+        {
+            return (await _db
+            .Library
+            .FirstOrDefaultAsync(a => a.Id == id));
+        }
+    }
+}

--- a/Take02/Services/RecipeService.cs
+++ b/Take02/Services/RecipeService.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Take02.Models;
+using Take02.ViewModels;
+
+namespace Take02.Services
+{
+    public interface IRecipeService
+    {
+        Task<ICollection<Recipe>> GetAllRecipesAsync();
+        Task<ICollection<MixType>> GetAllMixTypesAsync();
+
+        // Once this application scales past thousands of recipes, we'll
+        // have to adjust callers to this method and batch it somehow.
+        // However, we can just pull them all while the dataset is relatively
+        // small.
+        Task<ICollection<Ingredient>> GetAllIngredientsAsync();
+
+        Task<ICollection<Component>> GetAllComponentsAsync();
+        Task<ICollection<Unit>> GetAllUnitsAsync();
+    }
+
+    public class RecipeService : IRecipeService
+    {
+        private readonly CocktailsContext _db;
+
+        public RecipeService(CocktailsContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<ICollection<Recipe>> GetAllRecipesAsync()
+        {
+            return (await _db
+            .Recipe
+            .OrderBy(t => t.Name)
+            .ToListAsync());
+        }
+
+        public async Task<ICollection<MixType>> GetAllMixTypesAsync()
+        {
+            return (await _db.MixType.ToListAsync());
+        }
+
+        public async Task<ICollection<Ingredient>> GetAllIngredientsAsync()
+        {
+            return (await _db.Ingredient.ToListAsync());
+        }
+
+        public async Task<ICollection<Component>> GetAllComponentsAsync()
+        {
+            return (await _db.Component.ToListAsync());
+        }
+
+        public async Task<ICollection<Unit>> GetAllUnitsAsync()
+        {
+            return (await _db.Unit.ToListAsync());
+        }
+    }
+}

--- a/Take02/Startup.cs
+++ b/Take02/Startup.cs
@@ -7,8 +7,9 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
-using Take02.Models;
 using Take02.Import;
+using Take02.Models;
+using Take02.Services;
 
 namespace Take02
 {
@@ -38,6 +39,9 @@ namespace Take02
             services.AddTransient<IRawParser, RawParser>();
             services.AddTransient<IRecipeImporter, RecipeImporter>();
             services.AddTransient<IUnitImporter, UnitImporter>();
+
+            services.AddTransient<IRecipeService, RecipeService>();
+            services.AddTransient<ILibraryService, LibraryService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Take02/ViewModels/IngredientViewModel.cs
+++ b/Take02/ViewModels/IngredientViewModel.cs
@@ -30,6 +30,7 @@ namespace Take02.ViewModels
 
         public bool IsFirstIngredient { get; set; }
 
+        // TODO: these values should come from ViewData, not the ViewModel
         public List<SelectListItem> ComponentSelectListItems { get; set; }
 
         public List<SelectListItem> RecipeSelectListItems { get; set; }

--- a/Take02/appsettings.json
+++ b/Take02/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "CocktailsDatabase": ""
+    "CocktailsDatabase": "Data Source=dbprojects.cqxieikmyvba.us-west-2.rds.amazonaws.com,1433;Initial Catalog=cocktails;Persist Security Info=True;User ID=projectsmaster;Password=QirE3KlTSstE5GuBk5db"
   },
   "Logging": {
     "IncludeScopes": false,

--- a/Take02/appsettings.json
+++ b/Take02/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "CocktailsDatabase": "Data Source=dbprojects.cqxieikmyvba.us-west-2.rds.amazonaws.com,1433;Initial Catalog=cocktails;Persist Security Info=True;User ID=projectsmaster;Password=QirE3KlTSstE5GuBk5db"
+    "CocktailsDatabase": ""
   },
   "Logging": {
     "IncludeScopes": false,


### PR DESCRIPTION
Set up a couple of services to encapsulate DB calls. We can place more calls down in there as we sweep through more DB query optimizations as well.

This is a preferred pattern to a big `static class Helpers` for a few reasons:

- Smaller components which are easy to mentally grasp
- Defined responsibility for components (encapsulate recipe getting/setting vs. "do all of the DB stuff)
- Consuming controller is more testable because we can mock the dependencies as instances

This change sped up the load time for the Index of `RecipeController` by 80% (~10s down to ~2s running locally, it should be pretty quick on the AWS instance since it's on-network).

/ @andrewralon 