### PR TITLE
#13 Figure out Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: required
 mono: none
 dotnet: 2.1.2
 install:
-  - nuget restore Take02.sln
-  - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+  - dotnet install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
 script:
   - xbuild /p:Configuration=Release Take02.sln
   - dotnet restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: required
 mono: none
 dotnet: 2.1.2
 install:
- - nuget restore Take02.sln
- - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+  - nuget restore Take02.sln
+  - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
 script:
- - dotnet restore
- - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Take02.Tests/bin/Release/Take02.Tests.dll
+  - xbuild /p:Configuration=Release Take02.sln
+  - dotnet restore
+  - mono ./testrunner/xunit.runners.*/tools/xunit.console.clr4.exe ./Take02.Tests/bin/Release/Take02.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 mono: none
 dotnet: 2.1.2
 script:
-  - xbuild /p:Configuration=Release Take02.sln
   - dotnet restore
+  - dotnet build --configuration "Release"
   - dotnet test Take02.Tests
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+sudo: required
+mono: none
+dotnet: 2.1.2
+install:
+ - nuget restore Take02.sln
+ - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+script:
+ - dotnet restore
+ - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Take02.Tests/bin/Release/Take02.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: csharp
 sudo: required
 mono: none
 dotnet: 2.1.2
-install:
-  - dotnet install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
 script:
   - xbuild /p:Configuration=Release Take02.sln
   - dotnet restore
-  - mono ./testrunner/xunit.runners.*/tools/xunit.console.clr4.exe ./Take02.Tests/bin/Release/Take02.Tests.dll
+  - dotnet test Take02.Tests
+

--- a/Take02/Startup.cs
+++ b/Take02/Startup.cs
@@ -27,8 +27,8 @@ namespace Take02
         {
             services.AddMvc();
 
-            services.AddDbContext<CocktailsContext>(options =>
-                options.UseSqlServer(Configuration.GetConnectionString("CocktailsConnection")));
+            var cocktailsConnection = Configuration.GetConnectionString("CocktailsConnection");
+            services.AddDbContext<CocktailsContext>(options => options.UseSqlServer(cocktailsConnection));
 
             // Importer and dependencies
             services.AddTransient<IImporter, Importer>();


### PR DESCRIPTION
Here's what I learned about Travis-CI configs;

language: csharp
sudo: required // apparently
mono: none // mono isn't necessary for dotnet, saves time
dotnet: 2.1.2 // SDK version
script:
  - dotnet restore // use dotnet commands, not nuget!
  - dotnet build --configuration "Release" // instead of xbuild
  - dotnet test Take02.Tests // instead of xunit

![image](https://user-images.githubusercontent.com/9058120/35422918-01e5314c-0219-11e8-802f-6fbc553175ed.png)